### PR TITLE
Some modification for the report generation process and some troubleshooting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In the notebook file `generate_fact_sheet_results.ipynb`, you have to set some v
 (skip this if you want to use ipython notebook)
 
 You can use the script `generate_fact_sheet_results.py` to generate the factsheet results by execuring the following shell command with the required argumenets
- 
+
 ```
 python generate_factsheet_results.py \
 --CSV_PATH './data.csv' \
@@ -100,3 +100,19 @@ The PDF will have a summary of the results in a table and then individual result
 
 ## Note:
 The categories/classes are combined in a way in Step 1 that no category is repeated in super-categories.  
+
+
+
+## Troubleshooting
+
+* Be aware that the proper installation of `pdfkit` can need installing `wkhtmltopdf`. Check this https://github.com/JazzCore/python-pdfkit/wiki/Installing-wkhtmltopdf 
+
+For example, if you are on Debian / Ubuntu:
+
+```bash
+apt-get update
+apt-get install wkhtmltopdf
+```
+
+* If the pdf report files cannot be automatically generated, you can keep the html report files (use the option `--keep_html` for `generate_pdf_report.py`) and convert them to pdf manually, for example via the print functionality of Chrome.
+* You might encounter an issue of `Image size of ...x... pixels is too large. It must be less than 2^16 in each direction` if you have large number of classes. This problems comes from the generation of `descending_auc.png` in the function `generate_overall_auc_histogram_and_desc_auc_plot` of `generate_factsheet_results.py`. You can decrease the dpi in order to overcome this issue (decrease `X` in the line `fig.savefig(descending_categoris_auc_path, dpi=X)`).

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -12,6 +12,9 @@ parser.add_argument("--results_dir", type=str, required=True,  help="""The direc
 parser.add_argument("--title", type=str, required=True, help="""Title of the html and pdf file.""")
 
 parser.add_argument("--output_dir", type=str, default="./", help="""The directory where the html and pdf file will be stored. Default is current directory""")
+parser.add_argument("--keep_html", action="store_true", default=False, 
+    help="""Whether keep the html reports from which pdf reports can be built. 
+    This is useful if the conversion between html and pdf fails.""")
 
 args = parser.parse_args()
 
@@ -197,7 +200,8 @@ print("PDF File is Ready")
 print("###########################")
 print()
 
-os.remove(output_html)
+if not args.keep_html:
+    os.remove(output_html)
 
 
 

--- a/generate_pdf_report.py
+++ b/generate_pdf_report.py
@@ -24,8 +24,8 @@ output_dir = os.path.join('./', 'report_files')
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
-output_html = os.path.join(output_dir, 'report -- {}.html'.format(args.title))
-output_pdf = os.path.join(output_dir, 'report -- {}.pdf'.format(args.title))
+output_html = os.path.join(output_dir, 'report_{}.html'.format(args.title))
+output_pdf = os.path.join(output_dir, 'report_{}.pdf'.format(args.title))
 
 images_path = os.path.abspath(os.path.join(os.path.dirname( __file__ ), args.results_dir))
 
@@ -152,6 +152,15 @@ for super_cat in super_categories:
     
     
     episodes.append(super_cat_dic)
+
+# calculate the average AUC across episodes
+average_AUC = 0
+cnt = 0
+for episode in episodes:
+    average_AUC += float(episode["AUC"])
+    cnt += 1
+average_AUC /= cnt
+average_AUC = "{:.2f}".format(average_AUC)
     
     
 subs = jinja2.Environment(
@@ -161,7 +170,8 @@ subs = jinja2.Environment(
                                        total_categories=total_categories,
                                        categories_combined=categories_combined,
                                        over_all_auc_histogram=over_all_auc_histogram,
-                                       episodes=episodes)
+                                       episodes=episodes,
+                                       average_AUC=average_AUC)
 
 
 # lets write the substitution to a file

--- a/template.html
+++ b/template.html
@@ -46,6 +46,7 @@
     <!--    Statistics    -->
     <div class='bottom-30 '>
         <h2>Overall Statistics</h2>
+        <p>Average AUC: {{average_AUC}}</p>
         <p>Total Super Categories: {{total_super_categories}}</p>
         <p>Total Categories: {{total_categories}}</p>
         <p>Categories randomly combined: {{categories_combined}}</p>


### PR DESCRIPTION
The reasons:

1. I don't think it is a good idea to insert white space into file names, which is inconvenient for some automatic process on the terminal
2. I added the average AUC across episodes on top of the generated report, which is an essential information in my opinion
3. I added the possibility of keeping the html files (the option `--keep_html`), this is useful if the pdf conversion cannot be automatically done for various reasons. In this situation, users can choose to manually convert them e.g. via Chrome.
4. I added some troubleshooting (Q&A) information in the README